### PR TITLE
Fix type incompatibility in Fibonacci func 

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+export function fibonacci(n): number{
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -10,3 +10,15 @@ module.exports = function fibonacci(n) {
 
   return fibonacci(n - 1) + fibonacci(n - 2);
 };
+
+// module.exports = function fibonacci(n): number{
+//   if (n < 0) {
+//     return -1;
+//   } else if (n == 0) {
+//     return 0;
+//   } else if (n == 1) {
+//     return 1;
+//   }
+
+//   return fibonacci(n - 1) + fibonacci(n - 2);
+// };

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export function fibonacci(n): number{
+export function fibonacci(n: number): number{
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -10,15 +10,3 @@ export function fibonacci(n): number{
 
   return fibonacci(n - 1) + fibonacci(n - 2);
 };
-
-// module.exports = function fibonacci(n): number{
-//   if (n < 0) {
-//     return -1;
-//   } else if (n == 0) {
-//     return 0;
-//   } else if (n == 1) {
-//     return 1;
-//   }
-
-//   return fibonacci(n - 1) + fibonacci(n - 2);
-// };

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export function fibonacci(n): number{
+export function fibonacci(n: number): number{
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -9,16 +9,4 @@ export function fibonacci(n): number{
   }
 
   return fibonacci(n - 1) + fibonacci(n - 2);
-};
-
-// module.exports = function fibonacci(n): number{
-//   if (n < 0) {
-//     return -1;
-//   } else if (n == 0) {
-//     return 0;
-//   } else if (n == 1) {
-//     return 1;
-//   }
-
-//   return fibonacci(n - 1) + fibonacci(n - 2);
-// };
+}


### PR DESCRIPTION
There was type incompatibility in the Fibonacci function. Assigned a return type and parameter number type to fib function. I tested it locally by running `npm run test`. 

Closes #2